### PR TITLE
[hebing]适配UKylin2020版本，屏蔽三个功能解决无法启动问题；增加编译依赖

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -10,6 +10,7 @@ Build-Depends: debhelper (>= 11),
                libdbus-glib-1-dev,
                libdefaultprograms-dev,
                libkeyboardclient-dev,
+               libinterfaceclient-dev,
                libqt5x11extras5-dev,
                libxklavier-dev
 Standards-Version: 4.4.1

--- a/plugins/plugins.pro
+++ b/plugins/plugins.pro
@@ -6,10 +6,10 @@ SUBDIRS = \
           devices/printer \
           devices/keyboard \
           personalized/wallpaper \
-          personalized/theme \
-          personalized/fonts \
+          #personalized/theme \
+          #personalized/fonts \
           personalized/screensaver \
-          personalized/desktop \
+          #personalized/desktop \
           network/netconnect \
           network/vpn \
           network/proxy \


### PR DESCRIPTION
 * UKylin2020文件管理器使用peony-qt，功能未适配，暂时屏蔽使用到peony的三个功能
 * 增加编译依赖libinterfaceclient-dev