### PR TITLE
[hebing]加载插件时，对xml文件是否存在做判断防止段错误(时间和日期的依赖)

### DIFF
--- a/shell/mainwindow.cpp
+++ b/shell/mainwindow.cpp
@@ -31,6 +31,19 @@
 
 #include <QDebug>
 
+/* qt会将glib里的signals成员识别为宏，所以取消该宏
+ * 后面如果用到signals时，使用Q_SIGNALS代替即可
+ **/
+#ifdef signals
+#undef signals
+#endif
+
+extern "C" {
+#include <glib.h>
+#include <gio/gio.h>
+}
+
+
 MainWindow::MainWindow(QWidget *parent) :
     QMainWindow(parent),
     ui(new Ui::MainWindow)
@@ -190,6 +203,10 @@ void MainWindow::loadPlugins(){
     foreach (QString fileName, pluginsDir.entryList(QDir::Files)){
 //        if (!functionFilter(fileName)) //插件过滤，未安装则跳过
 //            continue;
+        //org.ukui.panel.indicators.gschema.xml不存在跳过
+        char * cfile = "/usr/share/glib-2.0/schemas/org.ukui.panel.indicators.gschema.xml";
+        if (!g_file_test(cfile, G_FILE_TEST_EXISTS) && fileName == "libdatetime.so")
+            continue;
 
         QPluginLoader loader(pluginsDir.absoluteFilePath(fileName));
         QObject * plugin = loader.instance();

--- a/shell/shell.pro
+++ b/shell/shell.pro
@@ -25,6 +25,12 @@ DEFINES += QT_DEPRECATED_WARNINGS
 
 include(../env.pri)
 
+##加载gio库和gio-unix库，用于处理desktop文件
+CONFIG        += link_pkgconfig \
+                 C++11
+PKGCONFIG     += gio-2.0 \
+                 gio-unix-2.0
+
 inst1.files += ukui-control-center.desktop
 inst1.path = /usr/share/applications
 inst2.files += $$PROJECT_ROOTDIR/pluginlibs/


### PR DESCRIPTION
 * 时间和日期依赖ukui-indicators的gsettings，社区不允许强依赖所以在mainwindowns做xml文件判断，防止段错误