### PR TITLE
Fix the return button on the top left did't work

### DIFF
--- a/shell/mainwindow.cpp
+++ b/shell/mainwindow.cpp
@@ -156,6 +156,12 @@ MainWindow::MainWindow(QWidget *parent) :
     //加载功能页Widget
     modulepageWidget = new ModulePageWidget(this);
     ui->stackedWidget->addWidget(modulepageWidget);
+
+    //top left return button
+    connect(ui->backBtn, &QPushButton::clicked, this, [=]{
+        if(ui->stackedWidget != nullptr)
+            ui->stackedWidget->setCurrentIndex(0);
+    });
 }
 
 MainWindow::~MainWindow()


### PR DESCRIPTION
fix #22.If you click return button on the top left, it should return current page to the control panel homepage.
