### PR TITLE
Fix build errors about QFile not declared

### DIFF
--- a/plugins/time-language/datetime/worldMap/zoneinfo.h
+++ b/plugins/time-language/datetime/worldMap/zoneinfo.h
@@ -1,6 +1,7 @@
 #ifndef ZONEINFO_H
 #define ZONEINFO_H
 
+#include <QFile>
 #include <QString>
 #include <QList>
 


### PR DESCRIPTION
```
worldMap/zoneinfo.cpp: In member function ‘QString ZoneInfo::readRile(const QString&)’:
worldMap/zoneinfo.cpp:10:5: error: ‘QFile’ was not declared in this scope
   10 |     QFile file(filepath);
      |     ^~~~~
worldMap/zoneinfo.cpp:11:8: error: ‘file’ was not declared in this scope; did you mean ‘fileno’?
   11 |     if(file.exists()) {
      |        ^~~~
      |        fileno
worldMap/zoneinfo.cpp:24:1: warning: control reaches end of non-void function [-Wreturn-type]
   24 | }
      | ^
make[2]: *** [Makefile:1366: zoneinfo.o] Error 1
```