### PR TITLE
Fix QPainterPath header missing when build on Archlinux

### DIFF
--- a/plugins/devices/audio/customstyle.cpp
+++ b/plugins/devices/audio/customstyle.cpp
@@ -2,7 +2,9 @@
 
 #include <QStyleOptionToolButton>
 #include <QPainter>
+#include <QPainterPath>
 #include <QApplication>
+
 CustomStyle::CustomStyle(const QString &proxyStyleName, QObject *parent) : QProxyStyle (proxyStyleName)
 {
     Q_UNUSED(parent);

--- a/plugins/devices/audio/ukmedia_slider_tip_label_helper.cpp
+++ b/plugins/devices/audio/ukmedia_slider_tip_label_helper.cpp
@@ -23,6 +23,7 @@
 #include <QStyle>
 #include <QDebug>
 #include <QPainter>
+#include <QPainterPath>
 #include <QStylePainter>
 #include <QMouseEvent>
 #include <QCoreApplication>


### PR DESCRIPTION
Build failed on Archlinux.

log:

```
ukui-control-center/plugins/devices/audio/customstyle.cpp:145:26: error: aggregate ‘QPainterPath path’ has incomplete type and cannot be defined
  145 |             QPainterPath path;
      |                          ^~~~
ukui-control-center/plugins/devices/audio/customstyle.cpp:156:26: error: aggregate ‘QPainterPath path’ has incomplete type and cannot be defined
  156 |             QPainterPath path;
      |                          ^~~~
ukui-control-center/plugins/devices/audio/ukmedia_slider_tip_label_helper.cpp: In member function ‘virtual void MediaSliderTipLabel::paintEvent(QPaintEvent*)’:
ukui-control-center/plugins/devices/audio/ukmedia_slider_tip_label_helper.cpp:47:18: error: aggregate ‘QPainterPath path’ has incomplete type and cannot be defined
   47 |     QPainterPath path;
      |                  ^~~~
```