### PR TITLE
hide start menu fullscreen settings @smiley286

### DIFF
--- a/plugins/personalized/desktop/desktop.cpp
+++ b/plugins/personalized/desktop/desktop.cpp
@@ -104,6 +104,9 @@ Desktop::Desktop()
 //    ui->menuFilesystemFrame->setVisible(false);
 //    ui->menuSettingFrame->setVisible(false);
 
+    ui->title2Label->hide();
+    ui->fullScreenMenuFrame->setVisible(false);
+
 
     vecGsettings = new QVector<QGSettings*>();
     const QByteArray id(DESKTOP_SCHEMA);


### PR DESCRIPTION
 * hide start menu fullscreen settings because no support