### PR TITLE
Movable control change to theme's control

### DIFF
--- a/plugins/account/networkaccount/editpassdialog.cpp
+++ b/plugins/account/networkaccount/editpassdialog.cpp
@@ -463,21 +463,6 @@ void EditPassDialog::paintEvent(QPaintEvent *event)
     painter.drawRoundedRect(rect, 6, 6);
 }
 
-/* 设置窗口可以动 */
-void EditPassDialog::mousePressEvent(QMouseEvent *event)
-{
-    if (event->button() == Qt::LeftButton) {
-        m_startPoint = frameGeometry().topLeft() - event->globalPos();
-    }
-}
-
-/* 设置窗口可以随鼠标动 */
-void EditPassDialog::mouseMoveEvent(QMouseEvent *event)
-{
-    this->move(event->globalPos() + m_startPoint);
-}
-
-
 /*　控件聚焦失去焦点事件处理 */
 bool EditPassDialog::eventFilter(QObject *w, QEvent *e) {
 //    if(w == account) {

--- a/plugins/account/networkaccount/editpassdialog.h
+++ b/plugins/account/networkaccount/editpassdialog.h
@@ -67,8 +67,6 @@ public slots:
     void            setret_edit(int ret);
 protected:
     void            paintEvent(QPaintEvent *event);
-    void            mousePressEvent(QMouseEvent *event);
-    void            mouseMoveEvent(QMouseEvent *event);
     bool            eventFilter(QObject *w,QEvent *e);
 private:
     QLabel          *m_title;

--- a/plugins/account/networkaccount/maindialog.cpp
+++ b/plugins/account/networkaccount/maindialog.cpp
@@ -1285,20 +1285,6 @@ void MainDialog::paintEvent(QPaintEvent *event)
     painter.drawRoundedRect(rect, 6, 6);
 }
 
-/* 使得窗口可以任意移动 */
-void MainDialog::mousePressEvent(QMouseEvent *event)
-{
-    if (event->button() == Qt::LeftButton) {
-        m_startPoint = frameGeometry().topLeft() - event->globalPos();
-    }
-}
-
-/* 按下鼠标使得窗口可以任意移动 */
-void MainDialog::mouseMoveEvent(QMouseEvent *event)
-{
-    this->move(event->globalPos() + m_startPoint);
-}
-
 /* 子控件事件过滤，主要针对获得或者失去焦点时捕捉 */
 bool MainDialog::eventFilter(QObject *w, QEvent *e) {
 

--- a/plugins/account/networkaccount/maindialog.h
+++ b/plugins/account/networkaccount/maindialog.h
@@ -108,8 +108,6 @@ public slots:
     void set_back();
 protected:
     void            paintEvent(QPaintEvent *event);
-    void            mousePressEvent(QMouseEvent *event);
-    void            mouseMoveEvent(QMouseEvent *event);
     bool            eventFilter(QObject *w,QEvent *e);
 
 private:


### PR DESCRIPTION
删除了自带的Frameless框拖动效果，使用主题拖动效果

Delete the original movable effect of frameless widget , and change to use the theme's frameless widget effect.