### PR TITLE
Fix:MainWindow automatically dragging with the mouse.

### DIFF
--- a/shell/mainwindow.cpp
+++ b/shell/mainwindow.cpp
@@ -441,7 +441,7 @@ void MainWindow::validBorder(){
     //    p.fillPath(rectPath,QColor(0,0,0));
         p.restore();
 
-        setContentsMargins(4, 4, 4, 4);
+//        setContentsMargins(4, 4, 4, 4);
         m_effect->setPadding(4);
 
         QPainterPath path;


### PR DESCRIPTION
修复主窗口被拖拽后，点击任意按钮会导致主窗口再次跟随鼠标自动拖拽的bug。