### PR TITLE
Fix:Limit the draging area of screens in the QQuickWidget.

### DIFF
--- a/plugins/system/display/declarative/qmlscreen.cpp
+++ b/plugins/system/display/declarative/qmlscreen.cpp
@@ -241,6 +241,15 @@ void QMLScreen::qmlOutputMoved(QMLOutput *qmlOutput)
 
     updateCornerOutputs();
 
+    if((qmlOutput->x() + qmlOutput->width()) > 550){
+//        qDebug()<<qmlOutput->x();
+        qmlOutput->setPosition(QPointF(550 - qmlOutput->width(), qmlOutput->y()));
+    }
+    if((qmlOutput->y() + qmlOutput->height()) > 190){
+//        qDebug()<<qmlOutput->y();
+        qmlOutput->setPosition(QPointF(qmlOutput->x(), 190 - qmlOutput->height()));
+    }
+
     if (m_leftmost) {
         m_leftmost->setOutputX(0);
     }

--- a/plugins/system/display/declarative/qmlscreen.cpp
+++ b/plugins/system/display/declarative/qmlscreen.cpp
@@ -241,11 +241,11 @@ void QMLScreen::qmlOutputMoved(QMLOutput *qmlOutput)
 
     updateCornerOutputs();
 
-    if((qmlOutput->x() + qmlOutput->width()) > 550){
+    if((qmlOutput->x() + qmlOutput->width()) > 550) {
 //        qDebug()<<qmlOutput->x();
         qmlOutput->setPosition(QPointF(550 - qmlOutput->width(), qmlOutput->y()));
     }
-    if((qmlOutput->y() + qmlOutput->height()) > 190){
+    if((qmlOutput->y() + qmlOutput->height()) > 190) {
 //        qDebug()<<qmlOutput->y();
         qmlOutput->setPosition(QPointF(qmlOutput->x(), 190 - qmlOutput->height()));
     }


### PR DESCRIPTION
修复:多屏下拖拽显示器小窗口可将其拖拽出窗口范围的BUG。
Link: http://172.17.66.192/biz/bug-view-19679.html