### PR TITLE
Fix:The sound setting is changed to ‘multi-channel output’, and the connector has not been changed accordingly. You need to restart the control panel and re-enter the device’s sound setting to change

### DIFF
--- a/plugins/devices/audio/ukmedia_main_widget.h
+++ b/plugins/devices/audio/ukmedia_main_widget.h
@@ -44,6 +44,7 @@ extern "C" {
 #include <QApplication>
 #include <QDomDocument>
 #include <QGSettings>
+#include <QAudioInput>
 
 #define UKUI_THEME_SETTING "org.ukui.style"
 #define UKUI_THEME_NAME "style-name"


### PR DESCRIPTION
Fix:The sound setting is changed to ‘multi-channel output’, and the connector has not been changed accordingly. You need to restart the control panel and re-enter the device’s sound setting to change
Link:http://172.17.66.192/biz/bug-view-22332.html