### PR TITLE
Solve the problem that the icon displayed on the tray is empty in the English state.

### DIFF
--- a/plugins/account/userinfo/createuserdialog.ui
+++ b/plugins/account/userinfo/createuserdialog.ui
@@ -364,6 +364,9 @@
                    <verstretch>0</verstretch>
                   </sizepolicy>
                  </property>
+                 <property name="styleSheet">
+                  <string notr="true">color:red;</string>
+                 </property>
                  <property name="text">
                   <string/>
                  </property>

--- a/plugins/personalized/desktop/desktop.cpp
+++ b/plugins/personalized/desktop/desktop.cpp
@@ -521,7 +521,7 @@ void Desktop::addTrayItem(QGSettings * trayGSetting) {
 
 QString Desktop::desktopToName(QString desktopfile) {
     const QString locale = QLocale::system().name();
-    const QString localeName = "Name[" + locale +"]";
+    const QString localeName = locale != "en_US" ? "Name[" + locale +"]" : "Name";
     const QString genericName = "GenericName[" + locale +"]";
     QSettings desktopSettings(desktopfile, QSettings::IniFormat);
 


### PR DESCRIPTION
解决在英文状态下，控制面板个性化显示在托盘上的图标为空问题。