### PR TITLE
Solve the problem that the icon displayed on the tray is empty in the English state and the problem that the introduction font can be deleted.

### DIFF
--- a/plugins/personalized/desktop/desktop.cpp
+++ b/plugins/personalized/desktop/desktop.cpp
@@ -521,7 +521,7 @@ void Desktop::addTrayItem(QGSettings * trayGSetting) {
 
 QString Desktop::desktopToName(QString desktopfile) {
     const QString locale = QLocale::system().name();
-    const QString localeName = "Name[" + locale +"]";
+    const QString localeName = locale != "en_US" ? "Name[" + locale +"]" : "Name";
     const QString genericName = "GenericName[" + locale +"]";
     QSettings desktopSettings(desktopfile, QSettings::IniFormat);
 

--- a/shell/ukccabout.cpp
+++ b/shell/ukccabout.cpp
@@ -94,6 +94,7 @@ void UkccAbout::initUI() {
     mUkccDetail = new QTextEdit(tr("The control panel provides a friendly graphical user interface to manage common configuration items of the operating system. "
                                 "System configuration provides system, equipment, personalization, network, account, time and date, account, time and date, update, notification and operation module operations. "));
 
+    mUkccDetail->setReadOnly(true);
     mUkccDetailLayout->addSpacing(32);
     mUkccDetailLayout->addWidget(mUkccDetail);
     mUkccDetailLayout->addSpacing(32);


### PR DESCRIPTION
解决系统环境英文状态下，控制面板个性化显示在托盘上的图标为空问题；解决控制面板关于中字体可编辑问题；