### PR TITLE
fix: the ukcc's dispaly rotation is different from kds

### DIFF
--- a/plugins/system/display/widget.cpp
+++ b/plugins/system/display/widget.cpp
@@ -348,11 +348,12 @@ void Widget::slotUnifyOutputs()
             nowIt.value()->setPos(QPoint(preIt.value()->pos().x() + preIt.value()->size().width(), 0));
             KScreen::ModeList modes = preIt.value()->modes();
             Q_FOREACH (const KScreen::ModePtr &mode, modes) {
-                if (preIt.value()->currentModeId() == mode->id()
-                        && (preIt.value()->rotation() != KScreen::Output::Rotation::Left && preIt.value()->rotation() != KScreen::Output::Rotation::Right)) {
-                    nowIt.value()->setPos(QPoint(preIt.value()->pos().x() + mode->size().width(), 0));
-                } else {
-                    nowIt.value()->setPos(QPoint(preIt.value()->pos().x() + mode->size().height(), 0));
+                if (preIt.value()->currentModeId() == mode->id()) {
+                    if (preIt.value()->rotation() != KScreen::Output::Rotation::Left && preIt.value()->rotation() != KScreen::Output::Rotation::Right) {
+                        nowIt.value()->setPos(QPoint(preIt.value()->pos().x() + mode->size().width(), 0));
+                    } else {
+                        nowIt.value()->setPos(QPoint(preIt.value()->pos().x() + mode->size().height(), 0));
+                    }
                 }
             }
             preIt = nowIt;

--- a/plugins/system/display/widget.h
+++ b/plugins/system/display/widget.h
@@ -130,6 +130,7 @@ private Q_SLOTS:
     void isWayland();
 
     void setDDCBrighthessSlot(int brightnessValue);// 设置外接显示器亮度
+    void kdsScreenchangeSlot();
 
 public Q_SLOTS:
     void save();


### PR DESCRIPTION
Description: the ukcc's dispaly rotation is different from kds

Log:与win+p显示的位置不同
Bug: http://pm.kylin.com/biz/bug-view-43212.html