### PR TITLE
Fix: crashed under SW64

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -44,8 +44,8 @@ Build-Depends: debhelper-compat (= 12),
 	       xserver-xorg-dev,
                libupower-glib-dev,
                libpam0g-dev,
-               yhkylin-backup-tools-dev(>=4.0.13-kylin19),
-               libukui-log4qt-dev
+               yhkylin-backup-tools-dev(>=4.0.13-kylin19)[!sw64],
+               libukui-log4qt-dev[!sw64]
 Standards-Version: 4.5.0
 Rules-Requires-Root: no
 Homepage: https://github.com/ukui/ukui-control-center

--- a/debian/rules
+++ b/debian/rules
@@ -11,8 +11,9 @@ DPKG_EXPORT_BUILDFLAGS = 1
 	dh $@
 
 # fix private dynamic library not found when debuild
-#override_dh_shlibdeps:
+override_dh_shlibdeps:
 #	dh_shlibdeps -l "${CURDIR}/cclibs"
+	dh_shlibdeps --dpkg-shlibdeps-params=--ignore-missing-info
 
 # fix private dynamic library lintian warning
 #override_dh_makeshlibs:

--- a/shell/main.cpp
+++ b/shell/main.cpp
@@ -48,7 +48,9 @@ int main(int argc, char *argv[])
 {
 
 #ifdef KYDEBUG
+#ifndef __sw_64__
     initUkuiLog4qt("ukui-control-center");
+#endif
 #endif
     QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
     QApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);

--- a/shell/mainwindow.cpp
+++ b/shell/mainwindow.cpp
@@ -546,6 +546,11 @@ void MainWindow::loadPlugins(){
              !g_file_test(sessionFile, G_FILE_TEST_EXISTS)) &&
                 (fileName == "libscreensaver.so" || fileName == "libscreenlock.so"))
             continue;
+#ifdef __sw_64__
+        if ("libpower.so" == fileName) {
+            continue;
+        }
+#endif
 
         const char * securityCmd = "/usr/sbin/ksc-defender";
 


### PR DESCRIPTION
Desc: SW64架构下使用日志SDK或者加载电源管理模块均会导致段错误
Log: 1. 适配SW64架构；
     2. SW64架构下不使用日志SDK且屏蔽电源管理模块