### PR TITLE
Fix

### DIFF
--- a/plugins/account/userinfo/createuserdialog.ui
+++ b/plugins/account/userinfo/createuserdialog.ui
@@ -419,7 +419,7 @@
         <item>
          <layout class="QVBoxLayout" name="verticalLayout_9">
           <property name="spacing">
-           <number>0</number>
+           <number>8</number>
           </property>
           <item>
            <widget class="QWidget" name="widget" native="true">

--- a/plugins/account/userinfo/userinfo.cpp
+++ b/plugins/account/userinfo/userinfo.cpp
@@ -458,7 +458,7 @@ void UserInfo::initComponent(){
 
     if (getuid()){
         ui->currentUserFaceLabel->installEventFilter(this);
-        ui->userNameLabel->installEventFilter(this);
+        ui->nameChangeWidget->installEventFilter(this);
     }
 
     //修改当前用户密码的回调
@@ -1159,7 +1159,7 @@ bool UserInfo::eventFilter(QObject *watched, QEvent *event){
                 return false;
             }
         }
-    } else if (watched == ui->userNameLabel){
+    } else if (watched == ui->nameChangeWidget){
         if (event->type() == QEvent::MouseButtonPress){
             QMouseEvent * mouseEvent = static_cast<QMouseEvent *>(event);
             if (mouseEvent->button() == Qt::LeftButton ){

--- a/plugins/account/userinfo/userinfo.ui
+++ b/plugins/account/userinfo/userinfo.ui
@@ -197,24 +197,63 @@
               </item>
               <item>
                <layout class="QHBoxLayout" name="horizontalLayout_6">
+                <property name="spacing">
+                 <number>0</number>
+                </property>
                 <item>
-                 <widget class="QLabel" name="userNameLabel">
-                  <property name="sizePolicy">
-                   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-                   </sizepolicy>
+                 <widget class="QWidget" name="nameChangeWidget" native="true">
+                  <property name="minimumSize">
+                   <size>
+                    <width>0</width>
+                    <height>0</height>
+                   </size>
                   </property>
-                  <property name="text">
-                   <string/>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QLabel" name="userNameChangeLabel">
-                  <property name="text">
-                   <string/>
-                  </property>
+                  <layout class="QHBoxLayout" name="horizontalLayout_18">
+                   <property name="leftMargin">
+                    <number>0</number>
+                   </property>
+                   <property name="topMargin">
+                    <number>0</number>
+                   </property>
+                   <property name="rightMargin">
+                    <number>0</number>
+                   </property>
+                   <property name="bottomMargin">
+                    <number>0</number>
+                   </property>
+                   <item>
+                    <widget class="QLabel" name="userNameLabel">
+                     <property name="sizePolicy">
+                      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                       <horstretch>0</horstretch>
+                       <verstretch>0</verstretch>
+                      </sizepolicy>
+                     </property>
+                     <property name="text">
+                      <string/>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QLabel" name="userNameChangeLabel">
+                     <property name="minimumSize">
+                      <size>
+                       <width>15</width>
+                       <height>22</height>
+                      </size>
+                     </property>
+                     <property name="maximumSize">
+                      <size>
+                       <width>15</width>
+                       <height>22</height>
+                      </size>
+                     </property>
+                     <property name="text">
+                      <string/>
+                     </property>
+                    </widget>
+                   </item>
+                  </layout>
                  </widget>
                 </item>
                </layout>


### PR DESCRIPTION
  * BUG: 增大用户账户中改名操作响应点击事件的区域
    - BUG#50607 【990】【控制面板|账户】改名的按钮不能点击
    - BUG#50757 【9A0】【控制面板|账户】点击改名的按钮不可修改，点击账户名位置可以修改用户
    - BUG#52377 【V10SP1】【控制面板|账户信息】建议增大更改用户名的点击范围
  * TASK：
  * OTHER: