### PR TITLE
Fix: bug54322 add tooltip for custom shortcut

### DIFF
--- a/plugins/devices/shortcut/shortcut.cpp
+++ b/plugins/devices/shortcut/shortcut.cpp
@@ -413,6 +413,7 @@ void Shortcut::buildCustomItem(KeyEntry *nkeyEntry)
     QFontMetrics fm(ft);
     QString nameStr = fm.elidedText(nkeyEntry->nameStr, Qt::ElideRight, 300);
     nameLabel->setText(nameStr);
+    nameLabel->setToolTip(nkeyEntry->nameStr);
 
     bindingLabel->setText(nkeyEntry->bindingStr);
     bindingLabel->setFixedWidth(240);


### PR DESCRIPTION
log：【控制面板|快捷键】添加快捷键名称超出显示时省略，建议鼠标悬停在上面时增加悬停提示完整的名称