### PR TITLE
Fix:bug #40387

### DIFF
--- a/plugins/account/networkaccount/mainwidget.cpp
+++ b/plugins/account/networkaccount/mainwidget.cpp
@@ -1258,9 +1258,9 @@ void MainWidget::showDesktopNotify(const QString &message)
                          "org.freedesktop.Notifications",
                          QDBusConnection::sessionBus());
     QList<QVariant> args;
-    args<<(QCoreApplication::applicationName())
+    args<<(tr("Kylin Cloud Account"))
     <<((unsigned int) 0)
-    <<QString("/usr/share/icons/ukui-icon-theme-default/scalable/apps/kylin-cloud-account.svg")
+    <<QString("kylin-cloud-account")
     <<tr("Cloud ID desktop message") //显示的是什么类型的信息
     <<message //显示的具体信息
     <<QStringList()

--- a/plugins/account/networkaccount/mainwidget.cpp
+++ b/plugins/account/networkaccount/mainwidget.cpp
@@ -332,12 +332,14 @@ void MainWidget::dbusInterface() {
                 m_manTimer->setSingleShot(true);
                 m_manTimer->setInterval(1000);
                 m_manTimer->start();
+                emit isSync(true);
                 return;
             }
             if (localDate == keyList.at(0) || !file.exists()) {
                 m_manTimer->setSingleShot(true);
                 m_manTimer->setInterval(1000);
                 m_manTimer->start();
+                emit isSync(true);
             } else {
                 m_autoSyn->make_itemoff();
                 m_pSettings->setValue("Auto-sync/enable","false");
@@ -366,6 +368,7 @@ void MainWidget::dbusInterface() {
                     m_manTimer->setSingleShot(true);
                     m_manTimer->setInterval(1000);
                     m_manTimer->start();
+                    emit isSync(true);
                 });
                 m_syncDialog->checkOpt();
                 m_syncDialog->show();
@@ -375,6 +378,7 @@ void MainWidget::dbusInterface() {
             m_manTimer->setSingleShot(true);
             m_manTimer->setInterval(1000);
             m_manTimer->start();
+            emit isSync(true);
         }
     });
 }


### PR DESCRIPTION
Description: translation:Kylin Cloud Account => 云账户

Log: 【云账户】云账户的通知信息，无个性化图标
Bug: http://172.17.66.192/biz/bug-view-40387.html

Signed-off-by: Peng Daixin <pengdaixin@kylinos.cn>