### PR TITLE
fix(netconnect):mac address

### DIFF
--- a/plugins/network/netconnect/netconnect.cpp
+++ b/plugins/network/netconnect/netconnect.cpp
@@ -760,14 +760,14 @@ int NetConnect::getActiveConInfo(QList<ActiveConInfo>& qlActiveConInfo) {
                                             "org.freedesktop.NetworkManager.Device.Wired",
                                             QDBusConnection::systemBus());
                 activeNet.strBandWidth = netDeviceifc.property("Speed").toString();
-                activeNet.strMac = netDeviceifc.property("HwAddress").toString();
+                activeNet.strMac = netDeviceifc.property("HwAddress").toString().toLower();
             } else {
                 QDBusInterface netDeviceifc("org.freedesktop.NetworkManager",
                                             replyDevicesPaths.at(0).path(),
                                             "org.freedesktop.NetworkManager.Device.Wireless",
                                             QDBusConnection::systemBus());
                 activeNet.strBandWidth = netDeviceifc.property("Bitrate").toString();
-                activeNet.strMac = netDeviceifc.property("HwAddress").toString();
+                activeNet.strMac = netDeviceifc.property("HwAddress").toString().toLower();
             }
             qlActiveConInfo.append(activeNet);
         }


### PR DESCRIPTION
description: Mac address is incorrectly capitalized
log:物理地址大小写不正确
bug:53631  【cpm】【HUAWEI】【KOS】【WIFI】【功能测试】【L2】网络详情里面的Mac地址与打开终端输入命令查询的地址字段不一致 【一般+必现+不常用功能】
