### PR TITLE
fix(Power management): Power management

### DIFF
--- a/plugins/system/power/power.cpp
+++ b/plugins/system/power/power.cpp
@@ -258,10 +258,7 @@ void Power::setupComponent() {
     ui->closeLidCombo->insertItem(1, closeLidStringList.at(1), "blank");
     ui->closeLidCombo->insertItem(2, closeLidStringList.at(2), "suspend");
     ui->closeLidCombo->insertItem(3, closeLidStringList.at(3), "shutdown");
-    if (!Utils::isWayland()){
-        closeLidStringList << tr("hibernate");
-        ui->closeLidCombo->insertItem(4, closeLidStringList.at(4), "hibernate");
-     }
+
     // 使用电池时屏幕变暗
     darkenStringList << tr("never") << tr("1 min") << tr("5 min") << tr("10 min") << tr("20 min");
     ui->darkenCombo->insertItem(0, darkenStringList.at(0), QVariant::fromValue(0));


### PR DESCRIPTION
Description: Delete closelid option

Log: 【电源管理】设置关闭笔记本电脑上盖为休眠，开盖唤醒，屏幕会闪烁，此时移动鼠标，无反应，过一会进入休眠
Bug: http://pm.kylin.com/biz/bug-view-52484.html