### PR TITLE
fix(search): Path of blocked folder is not complete & check values got from config file.

### DIFF
--- a/plugins/messages-task/search/search.cpp
+++ b/plugins/messages-task/search/search.cpp
@@ -228,7 +228,7 @@ int Search::setBlockDir(const QString &dirPath, const bool &is_add)
         }
     }
     m_dirSettings->setValue(pathKey, "0");
-    appendBlockDirToList(pathKey);
+    appendBlockDirToList(dirPath);
     return ReturnCode::Succeed;
 }
 
@@ -239,7 +239,10 @@ void Search::initBlockDirsList()
 {
     getBlockDirs();
     foreach (QString path, m_blockDirs) {
-        appendBlockDirToList(path);
+        QString wholePath = QString("/%1").arg(path);
+        if (QFileInfo(wholePath).isDir() && path.startsWith("home")) {
+            appendBlockDirToList(wholePath);
+        }
     }
 }
 


### PR DESCRIPTION
Log: 修复黑名单文件夹路径显示不完整的问题，检查获取的黑名单列表是否是文件夹
PS: 本修改不影响控制面板功能，但与v10sp1 bug:http://pm.kylin.com/biz/bug-view-55034.html 联动，建议尽早上传，确定合入日期后我将通知搜索传包同事同步传包