### PR TITLE
fix(bluetooth): 控制面板显示蓝牙设备中，去除不在范围的蓝牙设备

### DIFF
--- a/plugins/devices/bluetooth/bluetoothmain.h
+++ b/plugins/devices/bluetooth/bluetoothmain.h
@@ -83,6 +83,8 @@ private:
     QStringList paired_device_address;
     QString finally_connect_the_device;
     QStringList Discovery_device_address;
+    QStringList last_discovery_device_address;
+
     QStringList adapter_address_list;
     QStringList adapter_name_list;
 
@@ -117,6 +119,10 @@ private:
     QTimer *discovering_timer =nullptr;
     int i = 7;
     bool show_flag = false;
+
+    void clearUiShowDeviceList();
+    void addOneBluetoothDeviceItemUi(BluezQt::DevicePtr);
+
 };
 
 #endif // BLUETOOTHMAIN_H

--- a/plugins/devices/bluetooth/deviceinfoitem.cpp
+++ b/plugins/devices/bluetooth/deviceinfoitem.cpp
@@ -123,6 +123,24 @@ void DeviceInfoItem::resizeEvent(QResizeEvent *event)
 void DeviceInfoItem::enterEvent(QEvent *event)
 {
     AnimationFlag = true;
+
+    if (device_status->isVisible())
+    {
+        if (LINK == d_status)
+        {
+            device_status->setToolTip(tr("Device connected"));
+        }
+        else
+        {
+            device_status->setToolTip(tr("Device not connected"));
+        }
+        //else //正在连接状态为做对一切换，暂时不加入
+        //{
+        //    device_status->setToolTip(tr("Connecting device"));
+        //}
+
+    }
+
     mouse_timer->start();
 }
 


### PR DESCRIPTION
Description: Eliminate Bluetooth devices that are not in range #bug:54436

Log: 控制面板显示蓝牙设备中，去除不在范围的蓝牙设备