### PR TITLE
fix(netconnect):fix bug

### DIFF
--- a/plugins/network/netconnect/netconnect.cpp
+++ b/plugins/network/netconnect/netconnect.cpp
@@ -162,6 +162,9 @@ void NetConnect::initComponent() {
         if (m_interface) {
             m_interface->call("requestRefreshWifiList");
         }
+        if (!getWifiStatus()) {
+            getNetList();
+        }
     });
 
     connect(ui->detailBtn, &QPushButton::clicked, this, [=](bool checked) {
@@ -184,7 +187,6 @@ void NetConnect::initComponent() {
     ui->RefreshBtn->setEnabled(false);
     wifiBtn->setEnabled(false);
     ui->openWifiFrame->setVisible(false);
-
     emit ui->RefreshBtn->clicked(true);
     ui->verticalLayout_2->setContentsMargins(0, 0, 32, 0);
 }
@@ -221,6 +223,7 @@ void NetConnect::rebuildNetStatusComponent(QString iconPath, QString netName) {
         deviceItem->mDetailLabel->setText("");
     }
     QIcon searchIcon = QIcon::fromTheme(iconPath);
+    deviceItem->mPitIcon->setProperty("useIconHighlightEffect", 0x10);
     deviceItem->mPitIcon->setPixmap(searchIcon.pixmap(searchIcon.actualSize(QSize(24, 24))));
 
     deviceItem->mAbtBtn->setMinimumWidth(100);
@@ -472,7 +475,7 @@ int NetConnect::getWifiListDone(QVector<QStringList> getwifislist, QStringList g
             } else if (speed == "/") {
                 isNullSpeed = true;
             }
-            if (!getwifislist.isEmpty()) {
+            if (!getwifislist.isEmpty() && getwifislist.length() != 1) {
                 connectedWifi.clear();
                 wifiList.clear();
 


### PR DESCRIPTION
description:Fixed an empty display when not connected to a wired network
log:修复不连接有线网络，显示为空的问题
bug:56358
description:Fixed an issue where the connected network icon for dark themes was displayed incorrectly
log:修复深色主题已连接网络图标显示不正确的问题
bug:55336
