### PR TITLE
V10 fix(netconnect):Refresh the network to keep the page at the top

### DIFF
--- a/plugins/network/netconnect/netconnect.cpp
+++ b/plugins/network/netconnect/netconnect.cpp
@@ -712,6 +712,7 @@ void NetConnect::setWifiBtnDisable() {
     ui->RefreshBtn->setEnabled(false);
     wifiBtn->setEnabled(false);
     ui->openWifiFrame->setVisible(false);
+    this->clearContent();
 }
 
 void NetConnect::setNetDetailVisible() {


### PR DESCRIPTION
description: Refresh the network to keep the page at the top
log: 刷新网络保持页面置顶
bug:55340