### PR TITLE
fix(Fonts Slider): Fonts Slider

### DIFF
--- a/commonComponent/Uslider/uslider.cpp
+++ b/commonComponent/Uslider/uslider.cpp
@@ -37,6 +37,9 @@ void Uslider::paintEvent(QPaintEvent *e)
         int tickY = rect.height() / 2 + fontHeight + 5;
         for (int i=0; i <= numTicks; i++) {
             QRect fontRect = fontMetrics.boundingRect(scaleList.at(i));
+            if (i == numTicks) {
+                tickX -= 3;
+            }
 
             painter->drawText(QPoint(tickX, tickY),
                               this->scaleList.at(i));

--- a/plugins/personalized/fonts/fonts.cpp
+++ b/plugins/personalized/fonts/fonts.cpp
@@ -207,7 +207,7 @@ void Fonts::setupComponent(){
     uslider->setPageStep(1);
 
     ui->fontLayout->addWidget(uslider);
-    ui->fontLayout->addSpacing(1);
+
 
     //导入系统字体列表
     QStringList fontfamiles = fontdb.families();

--- a/plugins/personalized/fonts/fonts.ui
+++ b/plugins/personalized/fonts/fonts.ui
@@ -108,6 +108,9 @@
         <property name="leftMargin">
          <number>16</number>
         </property>
+        <property name="rightMargin">
+         <number>16</number>
+        </property>
         <item>
          <widget class="QLabel" name="fontSizeLabel">
           <property name="sizePolicy">


### PR DESCRIPTION
Description: Fonts Slider error

Log:  【控制面板|字体】字体设置栏16号字体右侧设计不合理
Bug: http://pm.kylin.com/biz/bug-view-52294.html