### PR TITLE
fix: update pre config when save monitor's config

### DIFF
--- a/plugins/system/display/widget.cpp
+++ b/plugins/system/display/widget.cpp
@@ -1202,6 +1202,7 @@ void Widget::save()
             writeFile(mDir % mPrevConfig->connectedOutputsHash());
         });
     } else {
+        mPrevConfig = mConfig->clone();
         writeScreenXml();
     }
 


### PR DESCRIPTION
Description: 应用后点击恢复之前的配置。系统会恢复登录后的分辨率以及方向

Log:应用后点击恢复之前的配置。系统会恢复登录后的分辨率以及方向
Bug: http://pm.kylin.com/biz/bug-view-56579.html