### PR TITLE
fix(ThemeUI): ThemeUI

### DIFF
--- a/plugins/personalized/theme/theme.cpp
+++ b/plugins/personalized/theme/theme.cpp
@@ -177,6 +177,7 @@ void Theme::setupSettings() {
     ui->effectFrame->setVisible(false);
     ui->transFrame->setVisible(false);
     ui->effectLabel->setVisible(false);
+    ui->verticalSpacer_5->changeSize(0,0);
     personliseGsettings->set(PERSONALSIE_EFFECT_KEY, false);
 }
 


### PR DESCRIPTION
Description: Spacing is too large

Log: 控制面板|主题】主题恢复默认设置按钮位置不合理
Bug: http://pm.kylin.com/biz/bug-view-57533.html