### PR TITLE
fix: crashed by OutputPtr's empty pointer

### DIFF
--- a/plugins/system/display/widget.cpp
+++ b/plugins/system/display/widget.cpp
@@ -1067,7 +1067,8 @@ void Widget::kdsScreenchangeSlot()
         KScreen::OutputPtr output = config->primaryOutput();
         if (config->connectedOutputs().count() >= 2) {
             foreach (KScreen::OutputPtr secOutput, config->connectedOutputs()) {
-                if (secOutput->geometry() != output->geometry() || !secOutput->isEnabled()) {
+                if ((output != nullptr) &&
+                        (secOutput->geometry() != output->geometry() || !secOutput->isEnabled())) {
                     cloneMode = false;
                 }
             }


### PR DESCRIPTION
Description: crashed by OutputPtr's empty pointer

Log: 双屏打开VGA显示器后开启统一输出崩溃
Bug: http://pm.kylin.com/biz/bug-view-57955.html