### PR TITLE
fix: crashed by outputr's empty pointer

### DIFF
--- a/plugins/system/display/widget.cpp
+++ b/plugins/system/display/widget.cpp
@@ -1169,7 +1169,7 @@ void Widget::save()
     }
 
     if (mIsWayland && -1 != mScreenId) {
-        if (enableScreenCount >= 2 && !config.isNull()) {
+        if (enableScreenCount >= 2 && !config.isNull() && !config->output(mScreenId).isNull()) {
             config->output(mScreenId)->setPrimary(true);
             callMethod(config->primaryOutput()->geometry(), config->primaryOutput()->name());
             if (mScreen->primaryOutput()) {


### PR DESCRIPTION
Description: crashed by outputr's empty pointer

Log: 关闭hdmi显示器，插拔vga,打开hdmi闪退
Bug: http://pm.kylin.com/biz/bug-view-54390.html