### PR TITLE
fix(search): Shielding password effectiveness in search

### DIFF
--- a/shell/searchwidget.cpp
+++ b/shell/searchwidget.cpp
@@ -236,6 +236,11 @@ void SearchWidget::loadxml() {
                                 || (!Utils::isCommunity() && m_searchBoxStruct.fullPagePath.contains("update")) ) {
                             break;
                         }
+#ifndef __sw_64__
+                        if(m_searchBoxStruct.fullPagePath.contains("Change valid",Qt::CaseInsensitive)) {
+                            break;
+                        }
+#endif
                         m_EnterNewPagelist.append(m_searchBoxStruct);
 
                         // Add search result content


### PR DESCRIPTION
Description: 在控制面板中可以索引到密码时效的信息并跳转，但实际没有该功能

Log: bug56558 && 53462