### PR TITLE
 Fixed the problem of not being able to find my device label when powering on and restarting after hibernation after the first pairing

### DIFF
--- a/plugins/devices/bluetooth/bluetoothmain.cpp
+++ b/plugins/devices/bluetooth/bluetoothmain.cpp
@@ -781,6 +781,10 @@ void BlueToothMain::adapterPoweredChanged(bool value)
         if(show_flag)
             frame_middle->setVisible(true);
 
+         if(!frame_middle->isVisible()){
+            frame_middle->setVisible(true);
+                }
+
         if (!open_bluetooth->isChecked())
             open_bluetooth->setChecked(true);
 


### PR DESCRIPTION
Fixed the problem of not being able to find my device label when powering on and restarting after hibernation after the first pairing