### PR TITLE
fix(display):When the shortcut key is used to switch to mirror mode, …

### DIFF
--- a/plugins/system/display/widget.cpp
+++ b/plugins/system/display/widget.cpp
@@ -423,6 +423,7 @@ void Widget::slotUnifyOutputs()
         ui->primaryCombo->setEnabled(false);
         ui->mainScreenButton->setEnabled(false);
         mControlPanel->setUnifiedOutput(base->outputPtr());
+        repaint();
     }
     Q_EMIT changed();
 }


### PR DESCRIPTION
…the unified output button will display an exception

log:使用快捷键切换为镜像模式后，开关统一输出按钮显示异常
bug:58780