### PR TITLE
fix(Power): Power

### DIFF
--- a/plugins/system/power/power.cpp
+++ b/plugins/system/power/power.cpp
@@ -560,8 +560,8 @@ void Power::initGeneralSet() {
         ui->powerLayout->addWidget(mBatteryAct);
 
         int batteryRemain = settings->get(PER_ACTION_CRI).toInt();
-        for(int i = 1; i < batteryRemain; i++) {
-            mBatteryAct->mNumCombox->insertItem(i - 1, QString("%1%").arg(i));
+        for(int i = 5; i < batteryRemain; i++) {
+            mBatteryAct->mNumCombox->insertItem(i - 5, QString("%1%").arg(i));
         }
 
         for(int i = 0; i < kBattery.length(); i++) {


### PR DESCRIPTION
Description: Power Setting

Log: cpm】【HUAWEI】【KOS】【电源管理】【V3】【L1】系统电源中“低电量执行操作”可设置1%-9%，实际3%电量时EC会下电关机，建议“低电量执行操作”设置区间为5%-9%。(提示+必现+常用功能)。
Bug: http://pm.kylin.com/biz/bug-view-59168.html