### PR TITLE
fix(display): fix bug#54951

### DIFF
--- a/plugins/system/display/widget.cpp
+++ b/plugins/system/display/widget.cpp
@@ -1468,7 +1468,7 @@ void Widget::checkOutputScreen(bool judge)
 // 亮度调节UI
 void Widget::initBrightnessUI()
 {
-    ui->brightnessSlider->setRange(0, 100);
+    ui->brightnessSlider->setRange(5, 100);
     if (mIsWayland && !mIsBattery) {
         connect(ui->brightnessSlider, &QSlider::valueChanged, this, &Widget::setDDCBrightness);
     } else {


### PR DESCRIPTION
Description: 笔记本调整亮度，快速拉动到暗笔记本黑屏无法恢复

Log: 亮度值最低为5
Bug: http://pm.kylin.com/biz/bug-view-54951.html