### PR TITLE
Fix:Display error when item sync failed

### DIFF
--- a/plugins/account/networkaccount/mainwidget.cpp
+++ b/plugins/account/networkaccount/mainwidget.cpp
@@ -646,6 +646,11 @@ void MainWidget::initSignalSlots() {
     connect(this, &MainWidget::isOnline, [=] (bool checked) {
         //如果本身发生了错误，进入同步错误状态，则不处理，接受同步错误状态的处理
         bool tmpOnline = m_bIsOnline;
+
+        if (m_mainWidget->currentWidget() == m_nullWidget) {
+            return ;
+        }
+
         m_bIsOnline = checked;
         if (m_bIsFailed) {
             if(checked == true) {
@@ -1041,6 +1046,7 @@ void MainWidget::ctrlAutoSync(int status) {
         m_autoSyn->set_change(0,"0");
         for (int i  = 0;i < m_szItemlist.size();i ++) {
             m_itemList->get_item(i)->set_active(true);
+            m_itemList->get_item(i)->set_change(0,"0");
         }
     }
 }


### PR DESCRIPTION
Description: 显示错误

Log: 当同步项同步出错时，感叹号图标不会消失，除非重开。
Bug: 自测BUG

Signed-off-by: Peng Daixin <pengdaixin@kylinos.cn>