### PR TITLE
fix(Notifycation): Notifycation

### DIFF
--- a/commonComponent/SwitchButton/switchbutton.cpp
+++ b/commonComponent/SwitchButton/switchbutton.cpp
@@ -204,7 +204,7 @@ void SwitchButton::mousePressEvent(QMouseEvent *event){
     else {
         endX = 0;
     }
-    return QWidget::mousePressEvent(event);
+    //return QWidget::mousePressEvent(event);
 }
 
 void SwitchButton::resizeEvent(QResizeEvent *){


### PR DESCRIPTION
Description: SwitchBtn question

Log: 【控制面板|通知】关闭设置通知来源中的“电源”的通知按钮时，不应该弹出子窗口
Bug: http://pm.kylin.com/biz/bug-view-59972.html