### PR TITLE
Fix:Adjust the input volume of the taskbar, the input volume value in the control panel does not change

### DIFF
--- a/plugins/devices/audio/ukmedia_main_widget.cpp
+++ b/plugins/devices/audio/ukmedia_main_widget.cpp
@@ -1921,6 +1921,9 @@ void UkmediaMainWidget::onStreamControlVolumeNotify (MateMixerStreamControl *m_p
         m_pWidget->m_pInputWidget->m_pIpVolumeSlider->blockSignals(true);
         m_pWidget->m_pInputWidget->m_pIpVolumeSlider->setValue(value);
         m_pWidget->m_pInputWidget->m_pIpVolumeSlider->blockSignals(false);
+        QString percentStr = QString::number(value) ;
+        percentStr.append("%");
+        m_pWidget->m_pInputWidget->m_pIpVolumePercentLabel->setText(percentStr);
     }
 }
 


### PR DESCRIPTION
Fix:Adjust the input volume of the taskbar, the input volume value in the control panel does not change

Bug:59123

Description:调节任务栏输入音量的大小，控制面板中输入音量数值没有变化