### PR TITLE
Fix(search):#57445 #61923 blocked folders can not be choosen when home path is not start with '/home'.

### DIFF
--- a/plugins/messages-task/search/search.cpp
+++ b/plugins/messages-task/search/search.cpp
@@ -236,7 +236,7 @@ int Search::setBlockDir(const QString &dirPath, const bool &is_add)
         removeBlockDirFromList(dirPath);
         return ReturnCode::Succeed;
     }
-    if (!dirPath.startsWith("/home")) {
+    if (!dirPath.startsWith(QDir::homePath())) {
         return ReturnCode::NotInHomeDir;
     }
 
@@ -254,7 +254,7 @@ int Search::setBlockDir(const QString &dirPath, const bool &is_add)
         //有它的子文件夹已被添加，删除这些子文件夹
         if (dir.startsWith(pathKey)) {
             m_dirSettings->remove(dir);
-            removeBlockDirFromList(dir);
+            removeBlockDirFromList("/" + dir);
         }
     }
     m_dirSettings->setValue(pathKey, "0");

--- a/shell/res/i18n/zh_CN.ts
+++ b/shell/res/i18n/zh_CN.ts
@@ -6608,7 +6608,7 @@ run start-pulseaudio-x11 manually.</source>
     <message>
         <location filename="../../../plugins/messages-task/search/search.cpp" line="163"/>
         <source>Choose folder</source>
-        <translation>添加要屏蔽的文件夹</translation>
+        <translation>选择要屏蔽的文件夹</translation>
     </message>
     <message>
         <location filename="../../../plugins/messages-task/search/search.cpp" line="312"/>


### PR DESCRIPTION
修复#57455 翻译问题
#61923 家目录不是"/home”时无法屏蔽文件夹问题