### PR TITLE
Fix(cloud accout):switch can not sync with real state

### DIFF
--- a/plugins/account/networkaccount/mainwidget.cpp
+++ b/plugins/account/networkaccount/mainwidget.cpp
@@ -638,7 +638,7 @@ void MainWidget::initSignalSlots() {
             if (m_itemMap.key(name) == "shortcut" && checked == true) {
                 showDesktopNotify(tr("This operation may cover your settings!"));
             }
-            m_pSettings->setValue(m_itemMap.key(name),checked ? "true" : "false");
+            m_pSettings->setValue(m_itemMap.key(name) + "/enable",checked ? "true" : "false");
             m_pSettings->sync();
             emit dochange(m_itemMap.key(name),checked);
         });

--- a/plugins/account/networkaccount/mainwidget.cpp
+++ b/plugins/account/networkaccount/mainwidget.cpp
@@ -638,6 +638,8 @@ void MainWidget::initSignalSlots() {
             if (m_itemMap.key(name) == "shortcut" && checked == true) {
                 showDesktopNotify(tr("This operation may cover your settings!"));
             }
+            m_pSettings->setValue(m_itemMap.key(name),checked ? "true" : "false");
+            m_pSettings->sync();
             emit dochange(m_itemMap.key(name),checked);
         });
     }


### PR DESCRIPTION
Description: switch can not sync with real state
Log: 修复开关会发生自动调整的问题