### PR TITLE
Fix:bug #56671

### DIFF
--- a/plugins/account/networkaccount/mainwidget.cpp
+++ b/plugins/account/networkaccount/mainwidget.cpp
@@ -638,6 +638,8 @@ void MainWidget::initSignalSlots() {
             if (m_itemMap.key(name) == "shortcut" && checked == true) {
                 showDesktopNotify(tr("This operation may cover your settings!"));
             }
+            m_pSettings->setValue(m_itemMap.key(name) + "/enable",checked ? "true" : "false");
+            m_pSettings->sync();
             emit dochange(m_itemMap.key(name),checked);
         });
     }


### PR DESCRIPTION
bug:56671
Description: switch can not sync with real state 
Log: 修复开关会发生自动调整的问题
Signed-off-by: Peng Daixin <pengdaixin@kylinos.cn>