### PR TITLE
fix(About UI): About UI

### DIFF
--- a/plugins/messages-task/about/about.cpp
+++ b/plugins/messages-task/about/about.cpp
@@ -274,6 +274,7 @@ void About::setupSerialComponent()
         if (!dateRes.isEmpty()) {
             ui->activeContent->setText(tr("Technical service has expired"));
             ui->timeContent->setText(dateRes);
+            ui->activeButton->setText(tr("Extended"));
         } else {
             ui->label->hide();
             ui->timeContent->hide();

--- a/plugins/messages-task/about/about.ui
+++ b/plugins/messages-task/about/about.ui
@@ -625,13 +625,13 @@
              </property>
              <property name="minimumSize">
               <size>
-               <width>121</width>
+               <width>130</width>
                <height>37</height>
               </size>
              </property>
              <property name="maximumSize">
               <size>
-               <width>121</width>
+               <width>130</width>
                <height>37</height>
               </size>
              </property>

--- a/shell/res/i18n/zh_CN.ts
+++ b/shell/res/i18n/zh_CN.ts
@@ -14,7 +14,12 @@
         <translation>已过期</translation>
     </message>
     <message>
-        <location filename="../../../plugins/messages-task/about/about.cpp" line="391"/>
+        <location filename="../../../plugins/messages-task/about/about.cpp" line="277"/>
+        <source>Extended</source>
+        <translation>延长服务</translation>
+    </message>
+    <message>
+        <location filename="../../../plugins/messages-task/about/about.cpp" line="392"/>
         <source>version</source>
         <translation>版本</translation>
         <extra-contents_path>/about/version</extra-contents_path>
@@ -48,21 +53,21 @@
     </message>
     <message>
         <location filename="../../../plugins/messages-task/about/about.ui" line="269"/>
-        <location filename="../../../plugins/messages-task/about/about.cpp" line="393"/>
+        <location filename="../../../plugins/messages-task/about/about.cpp" line="394"/>
         <source>Kernel</source>
         <translation>内核</translation>
         <extra-contents_path>/about/Kernel</extra-contents_path>
     </message>
     <message>
         <location filename="../../../plugins/messages-task/about/about.ui" line="308"/>
-        <location filename="../../../plugins/messages-task/about/about.cpp" line="395"/>
+        <location filename="../../../plugins/messages-task/about/about.cpp" line="396"/>
         <source>CPU</source>
         <translation>CPU</translation>
         <extra-contents_path>/about/CPU</extra-contents_path>
     </message>
     <message>
         <location filename="../../../plugins/messages-task/about/about.ui" line="356"/>
-        <location filename="../../../plugins/messages-task/about/about.cpp" line="397"/>
+        <location filename="../../../plugins/messages-task/about/about.cpp" line="398"/>
         <source>Memory</source>
         <translation>内存</translation>
         <extra-contents_path>/about/Memory</extra-contents_path>
@@ -142,7 +147,7 @@
         <translation type="vanished">可用</translation>
     </message>
     <message>
-        <location filename="../../../plugins/messages-task/about/about.cpp" line="280"/>
+        <location filename="../../../plugins/messages-task/about/about.cpp" line="281"/>
         <source>Inactivated</source>
         <translation>未激活</translation>
     </message>


### PR DESCRIPTION
Description: change button content

Log: 【系统授权】激活过期后按钮仍为“激活”非“延长服务”
Bug: http://zentao.kylin.com/biz/bug-view-54544.html