### PR TITLE
fix(Homepage UI): Homepage UI

### DIFF
--- a/shell/utils/functionselect.cpp
+++ b/shell/utils/functionselect.cpp
@@ -51,6 +51,7 @@ void FunctionSelect::initValue(){
     systemList[DISPLAY].namei18nString =  QObject::tr("Display");
     systemList[TOUCHSCREEN].nameString = QString("TouchScreen");
     systemList[TOUCHSCREEN].namei18nString =  QObject::tr("TouchScreen");
+    systemList[TOUCHSCREEN].mainShow = false;
     systemList[DEFAULTAPP].nameString = QString("Defaultapp");
     systemList[DEFAULTAPP].namei18nString =  QObject::tr("Default App");
     systemList[DEFAULTAPP].mainShow = false;


### PR DESCRIPTION
Description: change homepage display

Log: 【系统设置】16号字体下的系统设置的开机启动显示不全
Bug: http://zentao.kylin.com/biz/bug-view-63004.html