### PR TITLE
fix(Proxy): Proxy

### DIFF
--- a/shell/res/i18n/zh_CN.ts
+++ b/shell/res/i18n/zh_CN.ts
@@ -5259,7 +5259,7 @@ Please retry or relogin!</source>
     <message>
         <location filename="../../../plugins/network/proxy/proxy.ui" line="1041"/>
         <source>List of ignored hosts. more than one entry, please separate with english semicolon(;)</source>
-        <translation>忽略的主机列表，请使用英文分号（；）</translation>
+        <translation>忽略的主机列表，请使用英文分号（;）</translation>
     </message>
     <message>
         <source>proxy</source>


### PR DESCRIPTION
Description: Change translation

Log: 【控制面板|网络】点击代理，手动设置代理中提示符号实际为中文分号
Bug: http://zentao.kylin.com/biz/bug-view-61919.html