### PR TITLE
fix: plug and unplug the information display information error

### DIFF
--- a/plugins/system/display/controlpanel.cpp
+++ b/plugins/system/display/controlpanel.cpp
@@ -71,6 +71,7 @@ void ControlPanel::removeOutput(int outputId)
 {
     if (mUnifiedOutputCfg) {
         mUnifiedOutputCfg->setVisible(false);
+        mIsCloneMode = false;
     }
 
     for (OutputConfig *outputCfg : mOutputConfigs) {
@@ -87,7 +88,7 @@ void ControlPanel::removeOutput(int outputId)
 void ControlPanel::activateOutput(const KScreen::OutputPtr &output)
 {
     // Ignore activateOutput when in unified mode
-    if (mUnifiedOutputCfg) {
+    if (mUnifiedOutputCfg && mIsCloneMode) {
         return;
     }
 
@@ -140,6 +141,7 @@ void ControlPanel::setUnifiedOutput(const KScreen::OutputPtr &output)
         mUnifiedOutputCfg = new UnifiedOutputConfig(mConfig, this);
         mUnifiedOutputCfg->setOutput(output);
         mUnifiedOutputCfg->setVisible(true);
+        mIsCloneMode = true;
         mLayout->insertWidget(mLayout->count() - 2, mUnifiedOutputCfg);
         connect(mUnifiedOutputCfg, &UnifiedOutputConfig::changed,
                 this, &ControlPanel::changed);

--- a/plugins/system/display/controlpanel.h
+++ b/plugins/system/display/controlpanel.h
@@ -54,6 +54,7 @@ private:
     KScreen::OutputPtr mCurrentOutput;
 
     bool mIsWayland;
+    bool mIsCloneMode = false;
 };
 
 #endif // CONTROLPANEL_H


### PR DESCRIPTION
Description: plug and unplug the information display information error

Log: 接入4K外显，显示面板未同步更新4K外显信息
Bug: http://zentao.tjsource.xyz/biz/bug-view-62568.html