### PR TITLE
    fix(bluetooth): bluetooth

### DIFF
--- a/plugins/devices/bluetooth/bluetoothnamelabel.cpp
+++ b/plugins/devices/bluetooth/bluetoothnamelabel.cpp
@@ -130,6 +130,13 @@ void BluetoothNameLabel::enterEvent(QEvent *event)
 void BluetoothNameLabel::LineEdit_Input_Complete()
 {
     qDebug() << Q_FUNC_INFO;
+    if (m_lineedit->text().isEmpty())
+    {
+        m_lineedit->setText(device_name);
+        m_lineedit->update();
+        this->setStyleSheet("QWidget{border:none;border-radius:2px;}");
+    }
+
     if(device_name == m_lineedit->text()){
         set_label_text(device_name);
     }else{


### PR DESCRIPTION
    Description: Fix bluetooth

    Log: 【控制面板|蓝牙】双击蓝牙名称后删除，蓝牙名称框显示空白
    Bug: http://172.17.66.192/biz/bug-view-62832.html