### PR TITLE
fix(display): fix bug

### DIFF
--- a/plugins/system/display/outputconfig.h
+++ b/plugins/system/display/outputconfig.h
@@ -37,7 +37,7 @@ public:
     void initConfig(const KScreen::ConfigPtr &config);
 
 protected Q_SLOTS:
-    void slotResolutionChanged(const QSize &size);
+    void slotResolutionChanged(const QSize &size, bool emitFlag);
     void slotRotationChanged(int index);
     void slotRefreshRateChanged(int index);
     void slotScaleChanged(int index);

--- a/plugins/system/display/widget.cpp
+++ b/plugins/system/display/widget.cpp
@@ -1138,7 +1138,7 @@ void Widget::save()
 
     if (!KScreen::Config::canBeApplied(config)) {
         QMessageBox::information(this,
-                                 tr("Warnning"),
+                                 tr("Warning"),
                                  tr("Sorry, your configuration could not be applied.\nCommon reasons are that the overall screen size is too big, or you enabled more displays than supported by your GPU."));
         return;
     }

--- a/shell/mainwindow.cpp
+++ b/shell/mainwindow.cpp
@@ -904,7 +904,7 @@ void MainWindow::switchPage(QString moduleName, QString jumpMoudle) {
             }
         }
     }
-    QMessageBox::information(this, tr("Warnning"), tr("This function has been controlled"));
+    QMessageBox::information(this, tr("Warning"), tr("This function has been controlled"));
     return;
 }
 

--- a/shell/res/i18n/bo.ts
+++ b/shell/res/i18n/bo.ts
@@ -3157,7 +3157,7 @@ Please retry or relogin!</source>
     </message>
     <message>
         <location filename="../../mainwindow.cpp" line="833"/>
-        <source>Warnning</source>
+        <source>Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6039,7 +6039,7 @@ If something goes wrong, the settings will be restored after %1 seconds</source>
     </message>
     <message>
         <location filename="../../../plugins/system/display/widget.cpp" line="1005"/>
-        <source>Warnning</source>
+        <source>Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/shell/res/i18n/en_US.ts
+++ b/shell/res/i18n/en_US.ts
@@ -3230,7 +3230,7 @@ Please retry or relogin!</source>
     </message>
     <message>
         <location filename="../../mainwindow.cpp" line="905"/>
-        <source>Warnning</source>
+        <source>Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6571,7 +6571,7 @@ the settings will be saved after %1 seconds</source>
     </message>
     <message>
         <location filename="../../../plugins/system/display/widget.cpp" line="1141"/>
-        <source>Warnning</source>
+        <source>Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/shell/res/i18n/tr.ts
+++ b/shell/res/i18n/tr.ts
@@ -4224,7 +4224,7 @@ Please retry or relogin!</source>
     </message>
     <message>
         <location filename="../../mainwindow.cpp" line="934"/>
-        <source>Warnning</source>
+        <source>Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8403,7 +8403,7 @@ the settings will be saved after %1 seconds</source>
     </message>
     <message>
         <location filename="../../../plugins/system/display/widget.cpp" line="1140"/>
-        <source>Warnning</source>
+        <source>Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/shell/res/i18n/zh_CN.ts
+++ b/shell/res/i18n/zh_CN.ts
@@ -4369,7 +4369,7 @@ Please retry or relogin!</source>
     </message>
     <message>
         <location filename="../../mainwindow.cpp" line="905"/>
-        <source>Warnning</source>
+        <source>Warning</source>
         <translation>警告</translation>
     </message>
     <message>
@@ -8693,7 +8693,7 @@ If something goes wrong, the settings will be restored after %1 seconds</source>
     </message>
     <message>
         <location filename="../../../plugins/system/display/widget.cpp" line="1141"/>
-        <source>Warnning</source>
+        <source>Warning</source>
         <translation>警告</translation>
     </message>
     <message>


### PR DESCRIPTION
Description: bug#62995,【控制面板】【显示】打开显示模块，切换分辨率为a，点击恢复之前配置。刷新率处显示为空。此时点击刷新率，刷新率显示的是a分辨率下的刷新率列表。此时如果点击任意刷新率，会切换到分辨率a

Log: 点击恢复，触发当前显示ID变化时，刷新率下拉框重新填充
Bug: http://zentao.kylin.com/biz/bug-view-62995.html