### PR TITLE
fix(display): fix bug#62995

### DIFF
--- a/plugins/system/display/outputconfig.h
+++ b/plugins/system/display/outputconfig.h
@@ -37,7 +37,7 @@ public:
     void initConfig(const KScreen::ConfigPtr &config);
 
 protected Q_SLOTS:
-    void slotResolutionChanged(const QSize &size);
+    void slotResolutionChanged(const QSize &size, bool emitFlag);
     void slotRotationChanged(int index);
     void slotRefreshRateChanged(int index);
     void slotScaleChanged(int index);


### PR DESCRIPTION
Description: 打开显示模块，切换分辨率为a，点击恢复之前配置。刷新率处显示为空。此时点击刷新率，刷新率显示的是a分辨率下的刷新率列表。此时如果点击任意刷新率，会切换到分辨率a

Log: 点击恢复，触发当前显示ID变化时，刷新率下拉框重新填充
Bug: http://zentao.kylin.com/biz/bug-view-62995.html