### PR TITLE
	fix:repair bug

### DIFF
--- a/plugins/devices/bluetooth/bluetoothmain.cpp
+++ b/plugins/devices/bluetooth/bluetoothmain.cpp
@@ -591,6 +591,13 @@ void BlueToothMain::removeDeviceItemUI(QString address)
 void BlueToothMain::addMyDeviceItemUI(BluezQt::DevicePtr device)
 {
     qDebug() << __FUNCTION__ << device->name() << device->address() << device->type() << __LINE__;
+
+    DeviceInfoItem *item  = paired_dev_layout->findChild<DeviceInfoItem *>(device->address());
+    if (item)
+    {
+        return;
+    }
+
     connect(device.data(),&BluezQt::Device::typeChanged,this,[=](BluezQt::Device::Type  changeType){
 
         DeviceInfoItem *item = device_list->findChild<DeviceInfoItem *>(device->address());
@@ -720,6 +727,13 @@ void BlueToothMain::onClick_Open_Bluetooth(bool ischeck)
 
 void BlueToothMain::addOneBluetoothDeviceItemUi(BluezQt::DevicePtr device)
 {
+
+    DeviceInfoItem *item = device_list->findChild<DeviceInfoItem *>(device->address());
+    if (item)
+    {
+        return ;
+    }
+
     connect(device.data(),&BluezQt::Device::typeChanged,this,[=](BluezQt::Device::Type  changeType){
         DeviceInfoItem *item = device_list->findChild<DeviceInfoItem *>(device->address());
         if (item)
@@ -941,7 +955,7 @@ void BlueToothMain::adapterPoweredChanged(bool value)
         }
     }
 
-    switch_discover->setChecked(value);
+    //switch_discover->setChecked(value);
 }
 
 


### PR DESCRIPTION
	log:63000【蓝牙】已连接过的蓝牙鼠标，再次连接时需要重新点击连接，列表中显示2个重复名称
            62832【控制面板|蓝牙】双击蓝牙名称后删除，蓝牙名称框显示空白
	    44761【蓝牙】连接上蓝牙耳机后休眠，关闭蓝牙，再打开蓝牙，连接上耳机，控制面板中我的设备没有显示，任务栏有显示
            62724【蓝牙】【用例86978】蓝牙文件接收过程中取消，多次弹出确认窗口