### PR TITLE
53692 【cpm】【HUAWEI】【KOS】【安全】【V3】【L1】连续多次输入错误的旧口令，系统没有采用任何保护措施用于防暴力破解

### DIFF
--- a/changeUserPwd/main.cpp
+++ b/changeUserPwd/main.cpp
@@ -34,10 +34,10 @@ auth_cb (PasswdHandler *passwd_handler,
 
     if (error){
         g_warning("%s", error->message);
-        return;
+        qApp->exit(1);
+    } else {
+        passwd_change_password (passwd_handler, pwd, chpasswd_cb, NULL);
     }
-
-    passwd_change_password (passwd_handler, pwd, chpasswd_cb, NULL);
 
 }
 


### PR DESCRIPTION
  -衍生改动：pam密码校验与passwd密码校验走不同的锁定逻辑，当解锁时间不同时控制面板未对异常进行处理导致卡死，完善该逻辑