### PR TITLE
Fix Scale

### DIFF
--- a/plugins/system/display/controlpanel.h
+++ b/plugins/system/display/controlpanel.h
@@ -27,6 +27,7 @@ public:
     void setConfig(const KScreen::ConfigPtr &config);
     void setUnifiedOutput(const KScreen::OutputPtr &output);
     void activateOutputNoParam();
+    void changescalemax(const KScreen::OutputPtr &output);
 
 private:
     void isWayland();

--- a/plugins/system/display/display.pro
+++ b/plugins/system/display/display.pro
@@ -51,6 +51,7 @@ HEADERS += \
     controlpanel.h \
     outputconfig.h \
     resolutionslider.h \
+    scalesize.h \
     unifiedoutputconfig.h \
     utils.h \
     widget.h \

--- a/plugins/system/display/outputconfig.cpp
+++ b/plugins/system/display/outputconfig.cpp
@@ -10,6 +10,7 @@
 #include <QLabel>
 #include <QPushButton>
 #include <QGroupBox>
+#include <QMessageBox>
 
 #include <QComboBox>
 #include <QGSettings>
@@ -20,22 +21,7 @@
 
 #include "ComboBox/combobox.h"
 
-#define SCALE_SCHEMAS "org.ukui.SettingsDaemon.plugins.xsettings"
-#define SCALE_KEY     "scaling-factor"
-
-const QSize KRsolution(1920, 1080);
-
-const QVector<QSize> k150Scale{QSize(1280, 1024), QSize(1440, 900), QSize(1600, 900),
-                               QSize(1680, 1050), QSize(1920, 1080), QSize(1920, 1200),
-                               QSize(2048, 1080), QSize(2048, 1280), QSize(2160, 1440),
-                               QSize(2560, 1440),QSize(3840, 2160)};
-
-const QVector<QSize> k175Scale{QSize(1680, 1050), QSize(1920, 1080), QSize(1920, 1200),
-                               QSize(2048, 1080), QSize(2048, 1280), QSize(2160, 1440),
-                               QSize(2560, 1440), QSize(3840, 2160)};
-
-const QVector<QSize> k200Scale{QSize(1920, 1200), QSize(2048, 1280), QSize(2160, 1440),
-                               QSize(2560, 1440), QSize(3840, 2160)};
+double mScreenScale = 1.0;
 
 OutputConfig::OutputConfig(QWidget *parent) :
     QWidget(parent),
@@ -351,21 +337,46 @@ void OutputConfig::slotDPIChanged(QString key)
 
 void OutputConfig::slotScaleIndex(const QSize &size)
 {
+    QSize scalesize;
+
+    if (mScaleSize != QSize()) {
+        scalesize = size.width() > mScaleSize.width() ? mScaleSize : size;
+    } else {
+        scalesize = size;
+    }
+
+    if (!scalesize.isValid()) {
+        return;
+    }
+
     mScaleCombox->blockSignals(true);
     mScaleCombox->clear();
     mScaleCombox->addItem("100%", 1.0);
 
-
-    if (k150Scale.contains(size)) {
+    if (scalesize.width() >= 1024 ) {
         mScaleCombox->addItem("125%", 1.25);
+    }
+    if (scalesize.width() >= 1920 ) {
         mScaleCombox->addItem("150%", 1.5);
     }
-    if (k175Scale.contains(size)) {
+    if (scalesize.width() >= 2048) {
         mScaleCombox->addItem("175%", 1.75);
-    }
-    if (k200Scale.contains(size)) {
         mScaleCombox->addItem("200%", 2.0);
     }
+    if (scalesize.width() >= 3072) {
+        mScaleCombox->addItem("225%", 2.25);
+        mScaleCombox->addItem("250%", 2.5);
+    }
+    if (scalesize.width() >= 3072) {
+        mScaleCombox->addItem("275%", 2.75);
+    }
+
+    double scale = getScreenScale();
+    if (mScaleCombox->findData(scale) == -1) {
+        scale = 1.0;
+    }
+    mScaleCombox->setCurrentText(scaleToString(scale));
+    mScreenScale = scale;
     mScaleCombox->blockSignals(false);
 }
 

--- a/plugins/system/display/outputconfig.cpp
+++ b/plugins/system/display/outputconfig.cpp
@@ -359,7 +359,7 @@ void OutputConfig::slotScaleIndex(const QSize &size)
     if (scalesize.width() >= 1920 ) {
         mScaleCombox->addItem("150%", 1.5);
     }
-    if (scalesize.width() >= 2048) {
+    if (scalesize.width() >= 2560) {
         mScaleCombox->addItem("175%", 1.75);
         mScaleCombox->addItem("200%", 2.0);
     }
@@ -367,7 +367,7 @@ void OutputConfig::slotScaleIndex(const QSize &size)
         mScaleCombox->addItem("225%", 2.25);
         mScaleCombox->addItem("250%", 2.5);
     }
-    if (scalesize.width() >= 3072) {
+    if (scalesize.width() >= 3840) {
         mScaleCombox->addItem("275%", 2.75);
     }
 

--- a/plugins/system/display/outputconfig.h
+++ b/plugins/system/display/outputconfig.h
@@ -9,6 +9,8 @@
 
 #include <QGSettings>
 
+#include "scalesize.h"
+
 class QCheckBox;
 class ResolutionSlider;
 class QLabel;
@@ -43,7 +45,7 @@ protected Q_SLOTS:
     void slotScaleChanged(int index);
     void slotDPIChanged(QString key);
 
-private Q_SLOTS:
+public Q_SLOTS:
     void slotScaleIndex(const QSize &size);
 
 Q_SIGNALS:

--- a/plugins/system/display/scalesize.h
+++ b/plugins/system/display/scalesize.h
@@ -1,0 +1,33 @@
+#ifndef SCALESIZE_H
+#define SCALESIZE_H
+
+#include <QSize>
+
+#define SCALE_SCHEMAS "org.ukui.SettingsDaemon.plugins.xsettings"
+#define SCALE_KEY     "scaling-factor"
+
+const QSize KRsolution(1920, 1080);
+
+const QVector<QSize> k125Scale{QSize(1280, 1024), QSize(1440, 900), QSize(1600, 900),
+                               QSize(1680, 1050)};
+
+const QVector<QSize> k150Scale{ QSize(1920, 1080), QSize(1920, 1200),
+                               QSize(1920, 1280), QSize(2048, 1080), QSize(2048, 1280),
+                               QSize(2160, 1440), QSize(2560, 1440),QSize(3840, 2160)};
+
+const QVector<QSize> k175Scale{QSize(2048, 1080), QSize(2048, 1280), QSize(2160, 1440),
+                               QSize(2560, 1440), QSize(3840, 2160)};
+
+const QVector<QSize> k200Scale{QSize(2048, 1080), QSize(2048, 1280), QSize(2160, 1440),
+                               QSize(2560, 1440), QSize(3840, 2160)};
+
+const QVector<QSize> k250Scale{QSize(2560, 1440), QSize(3840, 2160)};
+
+const QVector<QSize> k275Scale{QSize(3840, 2160)};
+
+
+extern QSize  mScaleSize;
+
+extern double mScreenScale;
+
+#endif // SCALESIZE_H

--- a/plugins/system/display/unifiedoutputconfig.cpp
+++ b/plugins/system/display/unifiedoutputconfig.cpp
@@ -18,18 +18,6 @@
 #include <KF5/KScreen/kscreen/config.h>
 #include <KF5/KScreen/kscreen/getconfigoperation.h>
 
-const QVector<QSize> k150Scale{QSize(1280, 1024), QSize(1440, 900), QSize(1600, 900),
-                               QSize(1680, 1050), QSize(1920, 1080), QSize(1920, 1200),
-                               QSize(2048, 1080), QSize(2048, 1280), QSize(2160, 1440),
-                               QSize(2560, 1440),QSize(3840, 2160)};
-
-const QVector<QSize> k175Scale{QSize(1680, 1050), QSize(1920, 1080), QSize(1920, 1200),
-                               QSize(2048, 1080), QSize(2048, 1280), QSize(2160, 1440),
-                               QSize(2560, 1440), QSize(3840, 2160)};
-
-const QVector<QSize> k200Scale{QSize(1920, 1200), QSize(2048, 1280), QSize(2160, 1440),
-                               QSize(2560, 1440), QSize(3840, 2160)};
-
 bool operator<(const QSize &s1, const QSize &s2)
 {
     return s1.width() * s1.height() < s2.width() * s2.height();
@@ -387,7 +375,7 @@ void UnifiedOutputConfig::slotResolutionChanged(const QSize &size)
         }
     }
     if (mRefreshRate->count() == 0) {
-        mRefreshRate->addItem(tr("auto"), -1);    
+        mRefreshRate->addItem(tr("auto"), -1);
     }
     Q_EMIT changed();
 }

--- a/plugins/system/display/widget.cpp
+++ b/plugins/system/display/widget.cpp
@@ -642,6 +642,10 @@ bool Widget::isRestoreConfig()
         res = false;
         break;
     case QMessageBox::RejectRole:
+        QStringList keys = scaleGSettings->keys();
+        if (keys.contains("scalingFactor")) {
+            scaleGSettings->set(SCALE_KEY,scaleres);
+        }
         res = true;
         break;
     }
@@ -1166,7 +1170,7 @@ void Widget::setDDCBrightnessN(int value, QString screenName)
                            "com.control.center.interface",
                            QDBusConnection::systemBus());
 
-    
+
        if (mLock.tryLock()) {
             ukccIfc.call("setDDCBrightness", QString::number(value), type);
             mLock.unlock();
@@ -1393,7 +1397,7 @@ void Widget::save()
         return;
     }
 
-    writeScale(this->mScreenScale);
+    writeScale(mScreenScale);
     setNightMode(mNightButton->isChecked());
 
     if (!KScreen::Config::canBeApplied(config)) {
@@ -1626,8 +1630,8 @@ bool Widget::writeFile(const QString &filePath)
 
 void Widget::scaleChangedSlot(double scale)
 {
-    this->mScreenScale = scale;
-    if (scaleGSettings->get(SCALE_KEY).toDouble() != this->mScreenScale) {
+    mScreenScale = scale;
+    if (scaleGSettings->get(SCALE_KEY).toDouble() != mScreenScale) {
         mIsScaleChanged = true;
     } else {
         mIsScaleChanged = false;
@@ -1751,6 +1755,10 @@ void Widget::initConnection()
     ui->controlPanelLayout->addWidget(mControlPanel);
 
     connect(ui->applyButton, &QPushButton::clicked, this, [=]() {
+        QStringList keys = scaleGSettings->keys();
+        if (keys.contains("scalingFactor")) {
+            scaleres = scaleGSettings->get(SCALE_KEY).toDouble();
+        }
         save();
     });
 

--- a/plugins/system/display/widget.h
+++ b/plugins/system/display/widget.h
@@ -27,6 +27,7 @@
 #include "SwitchButton/switchbutton.h"
 #include "brightnessFrame.h"
 #include "screenConfig.h"
+#include "scalesize.h"
 
 class QLabel;
 class QMLOutput;
@@ -218,8 +219,9 @@ private:
 
     QHash<QString, QVariant> mNightConfig;
 
-    double mScreenScale = 1.0;
     int mScreenId = -1;
+
+    double scaleres;
 
     bool mIsNightMode     = false;
     bool mRedshiftIsValid = false;
@@ -234,7 +236,7 @@ private:
 
     bool threadRunExit = false;
     QFuture<void> threadRun;
-    
+
     QShortcut *mApplyShortcut;
     QVector<BrightnessFrame*> BrightnessFrameV;
     QVector<QString> deleteFrameNameV;  //用二级指针判断null出现问题，只想到这种方式排除段错误


### PR DESCRIPTION
Description: Fix Scale

Log: 【控制面板】控制面板中修改缩放屏幕后注销，再次登录系统后控制面板-缩放屏幕的比例显示的还是修改之前的比例 ;【cpm+已知】【KelvinV-W5821 5.6.0.13(C233) + BIOS 0.38+ EC 0.38】【HUAWEI】【graphic】【OS】【L2】【V3/V4】。复制模式调整缩放比例至150%，175%点击应用，注销后缩放比例回到了100%（严重+必现+不常用功能）

Bug: http://zentao.kylin.com/biz/bug-view-57319.html ;http://zentao.kylin.com/biz/bug-view-64421.html