### PR TITLE
 65531 【任务-控制面板-41834】添加依赖ddcutil，使得HDMI亮度调节可以使用

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -46,7 +46,6 @@ Build-Depends: debhelper-compat (= 12),
                libpam0g-dev,
                yhkylin-backup-tools-dev(>=4.0.13-kylin19)[!sw64],
                libukui-log4qt-dev[!sw64],
-               ddcutil,
 Standards-Version: 4.5.0
 Rules-Requires-Root: no
 Homepage: https://github.com/ukui/ukui-control-center
@@ -67,6 +66,7 @@ Depends: ${shlibs:Depends},
          kylin-xinput-calibrator,
          ukui-bluetooth,
          ukui-qt5xcb-plugin,
+         ddcutil,
 Suggests: gsettings-desktop-schemas,
           mate-desktop-common,
           ukui-power-manager,


### PR DESCRIPTION
  - 将ddcutil从编译依赖改到运行依赖