### PR TITLE
    fix(bluetooth): bluetooth

### DIFF
--- a/plugins/devices/bluetooth/bluetoothmain.cpp
+++ b/plugins/devices/bluetooth/bluetoothmain.cpp
@@ -828,8 +828,17 @@ void BlueToothMain::addOneBluetoothDeviceItemUi(BluezQt::DevicePtr device)
             device_list_layout->addWidget(item,Qt::AlignTop);
         else
         {
-            device_list_layout->insertWidget(0,item,0,Qt::AlignTop);
+            if (device->rssi() > MaxRssiValue)
+            {
+                qDebug() << __FUNCTION__ << "MaxRssiValue:" << MaxRssiValue << __LINE__;
+                MaxRssiValue = device->rssi();
+                device_list_layout->insertWidget(0,item,0,Qt::AlignTop);
+            }
+            else
+                device_list_layout->insertWidget(1,item,0,Qt::AlignTop);
+
         }
+
         last_discovery_device_address << device->address();
     }
 }

--- a/plugins/devices/bluetooth/bluetoothmain.h
+++ b/plugins/devices/bluetooth/bluetoothmain.h
@@ -137,6 +137,8 @@ private:
     void addOneBluetoothDeviceItemUi(BluezQt::DevicePtr);
 
     void clearAllDeviceItemUi();
+    qint16 MaxRssiValue = -9999;
+
 };
 
 #endif // BLUETOOTHMAIN_H

--- a/plugins/devices/bluetooth/deviceinfoitem.cpp
+++ b/plugins/devices/bluetooth/deviceinfoitem.cpp
@@ -211,7 +211,7 @@ void DeviceInfoItem::onClick_Connect_Btn(bool isclicked)
                 //device_status->update();
                 if (DEVICE_STATUS::MATCHED == d_status)
                     device_status->setText(tr("device matched"));
-                else if (DEVICE_STATUS::MATCHED == d_status)
+                else if (DEVICE_STATUS::UNLINK == d_status)
                     device_status->setText(tr("device unLink"));
             }
             connect_timer->stop();


### PR DESCRIPTION
    Description: bluetooth

    Log: 【控制面板】【蓝牙】控制面板“我的设备”中未显示已配对连接的windows设备
	 【蓝牙】已成功连接的手机，再次点击连接会出现白色感叹号
	 【控制面板】【蓝牙】设备列表中，连接设备未成功，停止在转圈界面的问题
	 【控制面板】【蓝牙】优化蓝牙设备列表显示信号最大在最前
    Bug:  http://zentao.kylin.com/biz/bug-view-64465.html
          http://zentao.kylin.com/biz/bug-view-64162.html