### PR TITLE
fix(display)

### DIFF
--- a/plugins/system/display/outputconfig.h
+++ b/plugins/system/display/outputconfig.h
@@ -39,7 +39,7 @@ public:
     void initConfig(const KScreen::ConfigPtr &config);
 
 protected Q_SLOTS:
-    void slotResolutionChanged(const QSize &size);
+    void slotResolutionChanged(const QSize &size, bool emitFlag);
     void slotRotationChanged(int index);
     void slotRefreshRateChanged(int index);
     void slotScaleChanged(int index);


### PR DESCRIPTION
bug: 49942 【控制面板|显示器】修改刷新率，点击恢复之前设置失败