### PR TITLE
fix: unified output problem

### DIFF
--- a/plugins/system/display/widget.cpp
+++ b/plugins/system/display/widget.cpp
@@ -352,9 +352,18 @@ void Widget::slotUnifyOutputs()
         if (mKDSCfg.isEmpty()) {
             KScreen::OutputList screens = mPrevConfig->connectedOutputs();
             QList<ScreenConfig> preScreenCfg = getPreScreenCfg();
+            int posX = preScreenCfg.at(0).screenPosX;
+            bool isOverlap = false;
+            for (int i = 1; i< preScreenCfg.count(); i++) {
+                if (posX == preScreenCfg.at(i).screenPosX) {
+                    isOverlap = true;
+                    setScreenKDS("expand");
+                    break;
+                }
+            }
             Q_FOREACH(ScreenConfig cfg, preScreenCfg) {
                 Q_FOREACH(KScreen::OutputPtr output, screens) {
-                    if (!cfg.screenId.compare(output->name())) {
+                    if (!cfg.screenId.compare(output->name()) && !isOverlap) {
                         output->setCurrentModeId(cfg.screenModeId);
                         output->setPos(QPoint(cfg.screenPosX, cfg.screenPosY));
                     }


### PR DESCRIPTION
Description: 打开统一输出选项，应用后桌面图层错乱重叠，实际显示模式为扩展模式。(一般+低概率+常用功能)

Log: 打开统一输出选项，应用后桌面图层错乱重叠，实际显示模式为扩展模式。(一般+低概率+常用功能)
Bug: https://zentao.tjsource.xyz/biz/bug-view-62566.html