### PR TITLE
fix: overlapping problems

### DIFF
--- a/plugins/system/display/declarative/qmlscreen.cpp
+++ b/plugins/system/display/declarative/qmlscreen.cpp
@@ -353,7 +353,8 @@ void QMLScreen::outputEnabledChanged()
     const KScreen::OutputPtr output(qobject_cast<KScreen::Output *>(sender()), [](void *){
         });
     if (output->isEnabled()) {
-        updateOutputsPlacement();
+        // bug#68442
+        // updateOutputsPlacement();
     }
     int enabledCount = 0;
 

--- a/plugins/system/display/widget.cpp
+++ b/plugins/system/display/widget.cpp
@@ -779,6 +779,11 @@ int Widget::getPrimaryScreenID()
     return screenId;
 }
 
+void Widget::setScreenIsApply(bool isApply)
+{
+    mIsScreenAdd = !isApply;
+}
+
 void Widget::showNightWidget(bool judge)
 {
     if (judge) {
@@ -1601,6 +1606,7 @@ void Widget::initConnection()
     connect(mUnifyButton, &SwitchButton::checkedChanged,
             [this] {
         slotUnifyOutputs();
+        setScreenIsApply(true);
         delayApply();
 		showBrightnessFrame();
     });

--- a/plugins/system/display/widget.h
+++ b/plugins/system/display/widget.h
@@ -168,6 +168,8 @@ private:
 
     int getPrimaryScreenID();
 
+    void setScreenIsApply(bool isApply);
+
 private:
     Ui::DisplayWindow *ui;
     QMLScreen *mScreen = nullptr;


### PR DESCRIPTION
Description: 关闭第二显示器后打开控制面板显示模块错位

Log: 关闭第二显示器后打开控制面板显示模块错位
Bug: http://zentao.kylin.com/biz/bug-view-68442.html