### PR TITLE
add download limit function to control panel

### DIFF
--- a/plugins/security-updates/upgrade/src/tabwidget.cpp
+++ b/plugins/security-updates/upgrade/src/tabwidget.cpp
@@ -36,6 +36,13 @@ void TabWid::initDbus()
     connect(isAutoBackupSBtn,&SwitchButton::checkedChanged,this,&TabWid::isAutoBackupChanged);
     connect(isAutoUpgradeSBtn, &SwitchButton::checkedChanged, this, &TabWid::isAutoUpgradeChanged);
     connect(updateSource,&UpdateSource::getReplyFalseSignal,this,&TabWid::getReplyFalseSlot);
+    connect(DownloadLimitBtn,&SwitchButton::checkedChanged,this,&TabWid::DownloadLimitSwitchChanged);
+    connect(DownloadLimitValue,static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged),this,&TabWid::DownloadLimitValueChanged);
+    //initialize download limit switch button
+    DownloadLimitBtn->setChecked(false);
+    //set download limit range
+    DownloadLimitValue->setRange(0,30000);
+    DownloadLimitValue->setValue(1000);
     //    bacupInit();//初始化备份
     isAutoBackupSBtn->setChecked(true);
     checkUpdateBtn->stop();
@@ -597,6 +604,20 @@ void TabWid::allComponents()
     isAutoBackupLayout->addWidget(isAutoBackupLab);
     isAutoBackupLayout->addWidget(isAutoBackupSBtn);
     isAutoBackupWidget->setLayout(isAutoBackupLayout);
+
+    //download speed limit
+    DownloadLimitWidget = new QFrame();
+    DownloadLimitWidget->setFrameShape(QFrame::Box);
+    DownloadLimitLayout = new QHBoxLayout();
+    DownloadLimitLab = new QLabel();
+    DownloadLimitLab->setText(tr("Download Limit"));
+    DownloadLimitBtn = new SwitchButton();
+    DownloadLimitValue = new QSpinBox();
+    DownloadLimitLayout->addWidget(DownloadLimitLab);
+    DownloadLimitLayout->addWidget(DownloadLimitValue);
+    DownloadLimitLayout->addWidget(DownloadLimitBtn);
+    DownloadLimitWidget->setLayout(DownloadLimitLayout);
+
     /*是否自动更新选项*/
     isAutoUpgradeWidget = new QFrame();
     isAutoUpgradeWidget->setFrameShape(QFrame::Box);
@@ -628,6 +649,9 @@ void TabWid::allComponents()
     updatesettingLayout->addWidget(isAutoCheckWidget);
     //    updatesettingLayout->addWidget(isAutoBackupWidget);
     updatesettingLayout->addWidget(isAutoUpgradeWidget);
+    updatesettingLayout->setSpacing(2);
+    updatesettingLayout->setMargin(0);
+    updatesettingLayout->addWidget(DownloadLimitWidget);
     updatesettingLayout->setSpacing(2);
     updatesettingLayout->setMargin(0);
 
@@ -899,6 +923,46 @@ void TabWid::checkUpdateBtnClicked()
             qDebug() << "Close 暂不更新!";
             break;
         }
+    }
+}
+
+void TabWid::DownloadLimitSwitchChanged()
+{
+    if(DownloadLimitBtn->isChecked()==false)
+    {
+        qDebug()<<"download limit disabled";
+        DownloadLimitValue->hide();
+        updateMutual->SetDownloadLimit(0,false);
+    }
+    else if (DownloadLimitBtn->isChecked()==true)
+    {
+        qDebug()<<"download limit enabled";
+        DownloadLimitValue->show();
+        int dlimit = DownloadLimitValue->value();
+        updateMutual->SetDownloadLimit(dlimit,true);
+    }
+    else
+    {
+        qWarning()<<"download limit disabled,this should not happen";
+        updateMutual->SetDownloadLimit(0,false);
+    }
+}
+
+void TabWid::DownloadLimitValueChanged(int value)
+{
+    if(DownloadLimitBtn->isChecked()==false)
+    {
+        updateMutual->SetDownloadLimit(0,false);
+    }
+    else if (DownloadLimitBtn->isChecked()==true)
+    {
+        //int dlimit = DownloadLimitValue->value();
+        updateMutual->SetDownloadLimit(value,true);
+    }
+    else
+    {
+        qDebug()<<"Download Limit Changed";
+        updateMutual->SetDownloadLimit(0,false);
     }
 }
 

--- a/plugins/security-updates/upgrade/src/tabwidget.h
+++ b/plugins/security-updates/upgrade/src/tabwidget.h
@@ -13,7 +13,7 @@
 #include <QCheckBox>
 #include <QFont>
 #include <QProgressBar>
-
+#include <QSpinBox>
 #include "appupdate.h"
 //#include "switchbutton.h"
 #include "m_updatelog.h"
@@ -88,6 +88,12 @@ public:
     QHBoxLayout *isAutoBackupLayout;
     QLabel *isAutoBackupLab;
     SwitchButton *isAutoBackupSBtn;
+    //download limit widgets
+    QFrame *DownloadLimitWidget;
+    QHBoxLayout *DownloadLimitLayout;
+    QLabel *DownloadLimitLab;
+    SwitchButton *DownloadLimitBtn;
+    QSpinBox *DownloadLimitValue;
 
     QFrame *isAutoUpgradeWidget;
     QVBoxLayout *isAutoUpgradeLayout;
@@ -135,7 +141,8 @@ public slots:
 
     void hideUpdateBtnSlot(bool isSucceed);
     void changeUpdateAllSlot(bool isUpdate);
-
+    void DownloadLimitSwitchChanged();
+    void DownloadLimitValueChanged(int);
     void getAllProgress(QString pkgName, int Progress, QString type);
     //调用源管理器相关
     void slotUpdateTemplate(QString status);

--- a/plugins/security-updates/upgrade/src/updatedbus.cpp
+++ b/plugins/security-updates/upgrade/src/updatedbus.cpp
@@ -48,7 +48,28 @@ UpdateDbus::UpdateDbus(QObject *parent)
     setImportantStatus(true);
 
 }
+void UpdateDbus::SetDownloadLimit(int value,bool whetherlimit)
+{
+    interface->call("set_downloadspeed_max",value,whetherlimit);
+}
 
+int UpdateDbus::GetDownloadLimit(void)
+{
+    QDBusPendingReply<int> reply = interface->call("get_downloadspeed_limit_value");
+    if (!reply.isValid())
+    {
+        qDebug()<<"error getting download speed limit value";
+        return -1;
+    }
+    if (reply.argumentAt(0)==true)
+    {
+        return reply.argumentAt(1).toInt();
+    }
+    else
+    {
+        return -2;
+    }
+}
 void UpdateDbus::onRequestSendDesktopNotify(QString message)
 {
     QDBusInterface iface("org.freedesktop.Notifications",

--- a/plugins/security-updates/upgrade/src/updatedbus.h
+++ b/plugins/security-updates/upgrade/src/updatedbus.h
@@ -83,6 +83,8 @@ public:
 //dbus接口函数定义完毕
     //
     void onRequestSendDesktopNotify(QString message);
+    void SetDownloadLimit(int,bool);
+    int GetDownloadLimit(void);
     QStringList inameList;  //重要更新列表
     QStringList importantList;
     QStringList failedList;

--- a/shell/res/i18n/zh_CN.ts
+++ b/shell/res/i18n/zh_CN.ts
@@ -7471,6 +7471,11 @@ run start-pulseaudio-x11 manually.</source>
         <extra-contents_path>/upgrade/Update Settings</extra-contents_path>
     </message>
     <message>
+        <location filename="../../../plugins/security-updates/upgrade/src/tabwidget.cpp" line="571"/>
+        <source>Download Limit</source>
+        <translation>下载限速</translation>
+    </message>
+    <message>
         <location filename="../../../plugins/security-updates/upgrade/src/tabwidget.cpp" line="583"/>
         <source>Allowed to renewable notice</source>
         <translation>允许通知可更新的应用</translation>


### PR DESCRIPTION
在控制面板中增加了下载限速的接口的调用界面（目前初始值为1000，上限30000，单位kb/s)。需要5.7.16kord版本以上kylin-update-manager