### PR TITLE
fix(changeUserPwd/run-passwd.cpp): format security

### DIFF
--- a/changeUserPwd/run-passwd.cpp
+++ b/changeUserPwd/run-passwd.cpp
@@ -377,7 +377,7 @@ static gboolean io_watch_stdout (GIOChannel *source, GIOCondition condition, Pas
                                          "Your password has been changed after you verify!");
                 } */else {
                     error = g_error_new (PASSWD_ERROR, PASSWD_ERROR_UNKNOWN,
-                                         str->str);
+                                         "%s", str->str);
                 }
 
                 /* At this point, passwd might have exited, in which case

--- a/changeUserPwd/run-passwd.cpp
+++ b/changeUserPwd/run-passwd.cpp
@@ -376,8 +376,8 @@ static gboolean io_watch_stdout (GIOChannel *source, GIOCondition condition, Pas
                     error = g_error_new (PASSWD_ERROR, PASSWD_ERROR_AUTH_FAILED,
                                          "Your password has been changed after you verify!");
                 } */else {
-                    error = g_error_new (PASSWD_ERROR, PASSWD_ERROR_UNKNOWN,
-                                         "%s", str->str);
+                    error = g_error_new_literal (PASSWD_ERROR, PASSWD_ERROR_UNKNOWN,
+                                         str->str);
                 }
 
                 /* At this point, passwd might have exited, in which case


### PR DESCRIPTION
Use `g_error_new_literal` instead of `g_error_new`, to fix the format string security issue.