### PR TITLE
fix(userinfo): createusernew

### DIFF
--- a/plugins/account/userinfo/createuserdialog.cpp
+++ b/plugins/account/userinfo/createuserdialog.cpp
@@ -428,7 +428,7 @@ void CreateUserDialog::nameLegalityCheck(QString username){
 
     if (username.isEmpty())
         nameTip = tr("The user name cannot be empty");
-    else if (username.startsWith("-")){
+    else if (username.startsWith("-") || (!mOutput.contains("xc") && username.left(1).contains((QRegExp("[0-9]"))))){
         nameTip = tr("Must be begin with lower letters!");
     }
     else if (!mOutput.contains("xc") && username.contains(QRegExp("[A-Z]"))){


### PR DESCRIPTION
Description: modify the rules of username

Log: 修改非华为云项目不可创建数字开头用户
Bug: https://172.17.50.104/biz/bug-view-105616.html