### PR TITLE
Fix build on non-`-fpermissive` compilers and riscv64

### DIFF
--- a/plugins/account/userinfo/giodbus.cpp
+++ b/plugins/account/userinfo/giodbus.cpp
@@ -18,7 +18,13 @@
 
 #include "giodbus.h"
 #include <gio/gio.h>
+
+#ifdef __riscv
+#include <glib-2.0/gio/gunixfdlist.h>
+#else
 #include <gio-unix-2.0/gio/gunixfdlist.h>
+#endif
+
 #include <glib.h>
 
 int get_server_gvariant_stdout (int drvid)

--- a/plugins/devices/audio/ukmedia_main_widget.cpp
+++ b/plugins/devices/audio/ukmedia_main_widget.cpp
@@ -1217,11 +1217,7 @@ xmlChar *UkmediaMainWidget::xmlGetAndTrimNames (xmlNodePtr node)
 
             if (cur_lang) {
                 for (j = 0; langs[j]; j++) {
-#ifdef __riscv
                     if (g_str_equal ((const char *) cur_lang, langs[j])) {
-#else
-                    if (g_str_equal (cur_lang, langs[j])) {
-#endif
                         cur_pri = j;
                         break;
                     }

--- a/plugins/devices/audio/ukmedia_main_widget.cpp
+++ b/plugins/devices/audio/ukmedia_main_widget.cpp
@@ -1217,7 +1217,11 @@ xmlChar *UkmediaMainWidget::xmlGetAndTrimNames (xmlNodePtr node)
 
             if (cur_lang) {
                 for (j = 0; langs[j]; j++) {
+#ifdef __riscv
+                    if (g_str_equal ((const char *) cur_lang, langs[j])) {
+#else
                     if (g_str_equal (cur_lang, langs[j])) {
+#endif
                         cur_pri = j;
                         break;
                     }


### PR DESCRIPTION
Fixes build on certain building environments where `-fpermissive` is not enabled by explicitly cast `xmlChar *` to `const char *`.

Also fixes riscv64 build by replacing wrong include path. See [Debian buildd log](https://buildd.debian.org/status/fetch.php?pkg=ukui-control-center&arch=riscv64&ver=3.0.5.1-1&stamp=1667424390&raw=0).

Tested on qemu-system-riscv64 and worked fine.